### PR TITLE
Fix funnel filter

### DIFF
--- a/funnel_explorer.view.lkml
+++ b/funnel_explorer.view.lkml
@@ -109,7 +109,7 @@ view: funnel_explorer {
 
     filters: {
       field: event1_before_event2
-      value: "true"
+      value: "Yes"
     }
   }
 
@@ -134,12 +134,12 @@ view: funnel_explorer {
 
     filters: {
       field: event1_before_event2
-      value: "true"
+      value: "Yes"
     }
 
     filters: {
       field: event2_before_event3
-      value: "true"
+      value: "Yes"
     }
   }
 }


### PR DESCRIPTION
The funnel_explorer was always showing 0 for `count_sessions_event12` and `count_sessions_event123`.  This changed fixed it.

Here's a before and after screenshot:

![funnel_before](https://user-images.githubusercontent.com/97163/29893041-c27e714c-8d9e-11e7-94f0-dedc6c585980.png)

![funnel_after](https://user-images.githubusercontent.com/97163/29893040-c278cae4-8d9e-11e7-9431-bfff6ca31a56.png)

Does this look correct?